### PR TITLE
Fix CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,8 @@ name: CI/CD
 
 on:
   pull_request_target:
-    branches: '**'
+    branches:
+      - '**'
 
 env:
   IMAGE_ROOT: docker.pkg.github.com/${{ github.repository }}
@@ -34,7 +35,7 @@ jobs:
           black --check .
       - name: Tests
         env:
-          SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          SECRET_KEY: ${{ secrets.CI_SECRET_KEY }}
           DEBUG: 0
         run: python manage.py test --settings=hackathon_site.settings.ci
 
@@ -82,7 +83,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [ backend-checks, event-checks, dashboard-checks ]
+    needs: [ backend-checks, template-checks, dashboard-checks ]
     if: github.ref == 'refs/heads/master'
     outputs:
       GITHUB_SHA_SHORT: ${{ steps.sha7.outputs.GITHUB_SHA_SHORT }}


### PR DESCRIPTION
## Overview

- Fixes two issues in the CI workflow:
    - It was invalid, since the build job dependend on `event-checks`, which was renamed to `template-checks`
    - It used the actual secret key in the `backend-checks` job (we never updated it when merging in the `pull_request_target` change from the template). Uses a new `CI_SECRET_KEY` now, which I've added as a repository secret.


