### PR TITLE
Hotfix: set-env is disabled

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get short SHA
         id: sha7
         run: |
-          echo "::set-env name=GITHUB_SHA_SHORT::$(echo ${{ github.sha }} | cut -c1-7)"
+          echo "GITHUB_SHA_SHORT=${GITHUB_SHA_SHORT}" >> $GITHUB_ENV
           echo "::set-output name=GITHUB_SHA_SHORT::$(echo ${{ github.sha }} | cut -c1-7)"
       - name: Build image
         run: docker-compose -f deployment/docker-compose.ci.yml build


### PR DESCRIPTION
## Overview

The `set-env` was disabled in workflows sometime in the last year. This seems to be the one line (I hope) of the workflow I forgot to update!

