### PR TITLE
Hotfix: Fix typo in registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  REGISTRY: ghrc.io
+  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   STACK_NAME: newhacks-site-2021
 


### PR DESCRIPTION
## Overview

Had a typo in the container registry url, causing failures
