### PR TITLE
Update allowed hosts and cors whitelist

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -44,10 +44,9 @@ if DEBUG:
     DEFAULT_FROM_EMAIL = "webmaster@localhost"
 
 else:
-    # NOTE: If you aren't ieee uoft, put your websites here
-    ALLOWED_HOSTS = ["ieee.utoronto.ca"]
+    ALLOWED_HOSTS = ["newhacks.ca", "www.newhacks.ca"]
     CORS_ORIGIN_REGEX_WHITELIST = [
-        r"^https://ieee\.utoronto.ca:?\d*$",
+        r"^https://(?:www.)?newhacks.ca:?\d*$",
     ]
 
     EMAIL_HOST = os.environ.get("EMAIL_HOST", None)

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -46,7 +46,7 @@ if DEBUG:
 else:
     ALLOWED_HOSTS = ["newhacks.ca", "www.newhacks.ca"]
     CORS_ORIGIN_REGEX_WHITELIST = [
-        r"^https://(?:www.)?newhacks.ca:?\d*$",
+        r"^https://(?:www\.)?newhacks.ca:?\d*$",
     ]
 
     EMAIL_HOST = os.environ.get("EMAIL_HOST", None)


### PR DESCRIPTION
## Overview

- Updates the allowed hosts and cors origin whitelists to work with newhacks.ca, instead of ieee.utoronto.ca
