### PR TITLE
Add recaptcha to signup form

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,8 @@ jobs:
           echo 'EMAIL_HOST_PASSWORD=${{ secrets.EMAIL_HOST_PASSWORD }}' >> .env
           echo 'EMAIL_FROM_ADDRESS=${{ secrets.EMAIL_FROM_ADDRESS }}' >> .env
           echo 'REDIS_URI=${{ secrets.REDIS_URI }}' >> .env
+          echo 'RECAPTCHA_PUBLIC_KEY=${{ secrets.RECAPTCHA_PUBLIC_KEY }}' >> .env
+          echo 'RECAPTCHA_PRIVATE_KEY=${{ secrets.RECAPTCHA_PRIVATE_KEY }}' >> .env
       - name: Transfer static files to the Swarm manager
         uses: appleboy/scp-action@v0.1.1
         with:

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -73,8 +73,12 @@ if DEBUG:
 else:
     # If the default test keys are used, the captcha package will create a system
     # check warning.
-    RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", RECAPTCHA_TEST_PUBLIC_KEY)
-    RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", RECAPTCHA_TEST_PRIVATE_KEY)
+    RECAPTCHA_PUBLIC_KEY = os.environ.get(
+        "RECAPTCHA_PUBLIC_KEY", RECAPTCHA_TEST_PUBLIC_KEY
+    )
+    RECAPTCHA_PRIVATE_KEY = os.environ.get(
+        "RECAPTCHA_PRIVATE_KEY", RECAPTCHA_TEST_PRIVATE_KEY
+    )
 
 # Application definition
 

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -18,10 +18,6 @@ from pathlib import Path
 import pytz
 
 from django.urls import reverse_lazy
-from captcha.constants import (
-    TEST_PUBLIC_KEY as CAPTCHA_TEST_PUBLIC_KEY,
-    TEST_PRIVATE_KEY as CAPTCHA_TEST_PRIVATE_KEY,
-)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
@@ -68,8 +64,8 @@ RECAPTCHA_DOMAIN = "www.recaptcha.net"
 if DEBUG:
     # These are special keys which will always allow requests to pass
     # verification
-    RECAPTCHA_PUBLIC_KEY = CAPTCHA_TEST_PUBLIC_KEY
-    RECAPTCHA_PRIVATE_KEY = CAPTCHA_TEST_PRIVATE_KEY
+    RECAPTCHA_PUBLIC_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+    RECAPTCHA_PRIVATE_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
     SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
 else:
     RECAPTCHA_PUBLIC_KEY = os.environ["RECAPTCHA_PUBLIC_KEY"]

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -18,6 +18,10 @@ from pathlib import Path
 import pytz
 
 from django.urls import reverse_lazy
+from captcha.constants import (
+    TEST_PUBLIC_KEY as CAPTCHA_TEST_PUBLIC_KEY,
+    TEST_PRIVATE_KEY as CAPTCHA_TEST_PRIVATE_KEY,
+)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
@@ -58,6 +62,19 @@ else:
 
 CORS_ALLOW_CREDENTIALS = True
 
+# reCaptcha settings
+RECAPTCHA_DOMAIN = "www.recaptcha.net"
+
+if DEBUG:
+    # These are special keys which will always allow requests to pass
+    # verification
+    RECAPTCHA_PUBLIC_KEY = CAPTCHA_TEST_PUBLIC_KEY
+    RECAPTCHA_PRIVATE_KEY = CAPTCHA_TEST_PRIVATE_KEY
+    SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
+else:
+    RECAPTCHA_PUBLIC_KEY = os.environ["RECAPTCHA_PUBLIC_KEY"]
+    RECAPTCHA_PRIVATE_KEY = os.environ["RECAPTCHA_PRIVATE_KEY"]
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -75,6 +92,7 @@ INSTALLED_APPS = [
     "drf_yasg",
     "import_export",
     "django_filters",
+    "captcha",
     "dashboard",
     "registration",
     "event",

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -61,15 +61,20 @@ CORS_ALLOW_CREDENTIALS = True
 # reCaptcha settings
 RECAPTCHA_DOMAIN = "www.recaptcha.net"
 
+RECAPTCHA_TEST_PUBLIC_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+RECAPTCHA_TEST_PRIVATE_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
+
 if DEBUG:
     # These are special keys which will always allow requests to pass
     # verification
-    RECAPTCHA_PUBLIC_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
-    RECAPTCHA_PRIVATE_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
+    RECAPTCHA_PUBLIC_KEY = RECAPTCHA_TEST_PUBLIC_KEY
+    RECAPTCHA_PRIVATE_KEY = RECAPTCHA_TEST_PRIVATE_KEY
     SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]
 else:
-    RECAPTCHA_PUBLIC_KEY = os.environ["RECAPTCHA_PUBLIC_KEY"]
-    RECAPTCHA_PRIVATE_KEY = os.environ["RECAPTCHA_PRIVATE_KEY"]
+    # If the default test keys are used, the captcha package will create a system
+    # check warning.
+    RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", RECAPTCHA_TEST_PUBLIC_KEY)
+    RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", RECAPTCHA_TEST_PRIVATE_KEY)
 
 # Application definition
 

--- a/hackathon_site/hackathon_site/settings/ci.py
+++ b/hackathon_site/hackathon_site/settings/ci.py
@@ -20,6 +20,11 @@ and by running your code before you merge it.
 """
 from hackathon_site.settings import *
 
+from captcha.constants import (
+    TEST_PUBLIC_KEY as CAPTCHA_TEST_PUBLIC_KEY,
+    TEST_PRIVATE_KEY as CAPTCHA_TEST_PRIVATE_KEY,
+)
+
 # Convenient for some methods to test, since DEBUG=0 in testing
 IN_TESTING = True
 
@@ -38,3 +43,9 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 if not os.path.isdir(MEDIA_ROOT):
     os.makedirs(MEDIA_ROOT)
+
+# In testing, captchas should always pass. These are special keys
+# which will allow all verification requests to pass.
+RECAPTCHA_PUBLIC_KEY = CAPTCHA_TEST_PUBLIC_KEY
+RECAPTCHA_PRIVATE_KEY = CAPTCHA_TEST_PRIVATE_KEY
+SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]

--- a/hackathon_site/hackathon_site/settings/ci.py
+++ b/hackathon_site/hackathon_site/settings/ci.py
@@ -20,11 +20,6 @@ and by running your code before you merge it.
 """
 from hackathon_site.settings import *
 
-from captcha.constants import (
-    TEST_PUBLIC_KEY as CAPTCHA_TEST_PUBLIC_KEY,
-    TEST_PRIVATE_KEY as CAPTCHA_TEST_PRIVATE_KEY,
-)
-
 # Convenient for some methods to test, since DEBUG=0 in testing
 IN_TESTING = True
 
@@ -46,6 +41,6 @@ if not os.path.isdir(MEDIA_ROOT):
 
 # In testing, captchas should always pass. These are special keys
 # which will allow all verification requests to pass.
-RECAPTCHA_PUBLIC_KEY = CAPTCHA_TEST_PUBLIC_KEY
-RECAPTCHA_PRIVATE_KEY = CAPTCHA_TEST_PRIVATE_KEY
+RECAPTCHA_PUBLIC_KEY = "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+RECAPTCHA_PRIVATE_KEY = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"
 SILENCED_SYSTEM_CHECKS = ["captcha.recaptcha_test_key_error"]

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
+from captcha.fields import ReCaptchaField
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
@@ -21,6 +22,8 @@ class SignUpForm(UserCreationForm):
     username is automatically set to be the email. This is ultimately
     simpler than creating a custom user model to use email as username.
     """
+
+    captcha = ReCaptchaField()
 
     error_css_class = "invalid"
 

--- a/hackathon_site/registration/jinja2/registration/signup.html
+++ b/hackathon_site/registration/jinja2/registration/signup.html
@@ -14,6 +14,7 @@
     {{ render_field(form.last_name) }}
     {{ render_field(form.password1, show_help_text=True) }}
     {{ render_field(form.password2) }}
+    {{ render_field(form.captcha) }}
 
     {% if form.non_field_errors() %}
         {% for error in form.non_field_errors() %}

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -69,6 +69,7 @@ class SignUpFormTestCase(TestCase):
             "last_name": "Bar",
             "password1": "abcdef456",
             "password2": "abcdef456",
+            "g-recaptcha-response": "PASSED",
         }
         form = SignUpForm(data=data)
         self.assertTrue(form.is_valid())

--- a/hackathon_site/registration/test_views.py
+++ b/hackathon_site/registration/test_views.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from unittest.mock import patch
 
 from django.conf import settings
@@ -38,7 +38,7 @@ class SignUpViewTestCase(SetupUserMixin, TestCase):
         missing error is the simplest
         """
         response = self.client.post(self.view, {})
-        self.assertContains(response, "This field is required", count=5)
+        self.assertContains(response, "This field is required", count=6)
 
     def test_valid_submit_redirect(self):
         data = {
@@ -47,6 +47,7 @@ class SignUpViewTestCase(SetupUserMixin, TestCase):
             "last_name": "Bar",
             "password1": "abcdef456",
             "password2": "abcdef456",
+            "g-recaptcha-response": "PASSED",
         }
         response = self.client.post(self.view, data)
         self.assertRedirects(response, reverse("registration:signup_complete"))
@@ -60,6 +61,7 @@ class SignUpViewTestCase(SetupUserMixin, TestCase):
             "last_name": "Bar",
             "password1": "abcdef456",
             "password2": "abcdef456",
+            "g-recaptcha-response": "PASSED",
         }
         self.client.post(self.view, data)
         self.assertTrue(

--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -12,6 +12,7 @@ django-cors-headers==3.3.0
 django-debug-toolbar==2.2.1
 django-filter==2.4.0
 django-import-export==2.5.0
+django-recaptcha==2.0.6
 django-redis==4.12.1
 django-registration==3.1.2
 djangorestframework==3.11.2


### PR DESCRIPTION
## Overview

Adds a captcha (reCaptcha v2) to the signup form to counter the spam we've been getting.

![image](https://user-images.githubusercontent.com/26036279/134705096-2a2cd035-4a02-4e7b-b4c6-bcfbbacdfc65.png)

Note that the warning message on the captcha will only be present locally.

The necessary keys have already been setup as repository secrets.

## Unit Tests Created

- Update existing tests, no dediicated tests

## Steps to QA

- Not much that can be done locally, need to verify in production. But you should still launch the signup page locally to make sure it works there.

