### PR TITLE
Add details about swag to the acceptance email

### DIFF
--- a/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
@@ -4,7 +4,11 @@
 
 <p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}!
 
-<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
+<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p>
+
+<p>If you'd like us to ship you some {{ hackathon_name }} swag, fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSePBlW8gLKOi27-8uUGTaUJMcywHT75RjziKOcii4yQvMYYSA/viewform">this Google form</a>! If you are in Toronto and would like to come pick up swag early instead, come to the front of the Galbraith building (35 St. George St, Toronto, ON, M5S 1A4) on Monday, October 25th, 2021 from 12:15 to 1pm!</p>
+
+<p>If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
 
 <p>Happy hacking,<br>
 The {{ hackathon_name }} Team


### PR DESCRIPTION
## Overview

Adds a google form link and details about when to pick up swag for NewHacks

Presumably, tomorrow this will have to be edited again to remove the early pickup details for the next time we send them out. That's easier than coding up logic to ommit it for us.

## Unit Tests Created

- None


## Steps to QA

- None really

