### PR TITLE
Extend registration to November 3rd

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -293,7 +293,7 @@ CONTACT_EMAIL = DEFAULT_FROM_EMAIL
 
 REGISTRATION_OPEN_DATE = datetime(2021, 9, 3, tzinfo=pytz.timezone(TIME_ZONE))
 REGISTRATION_CLOSE_DATE = datetime(
-    2021, 10, 29, 23, 59, 59, tzinfo=pytz.timezone(TIME_ZONE)
+    2021, 11, 3, 23, 59, 59, tzinfo=pytz.timezone(TIME_ZONE)
 )
 EVENT_START_DATE = datetime(2021, 11, 6, 10, 0, 0, tzinfo=pytz.timezone(TIME_ZONE))
 EVENT_END_DATE = datetime(2021, 11, 7, 17, 0, 0, tzinfo=pytz.timezone(TIME_ZONE))

--- a/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
@@ -6,7 +6,7 @@
 
 <p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p>
 
-<p>If you'd like us to ship you some {{ hackathon_name }} swag, fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSePBlW8gLKOi27-8uUGTaUJMcywHT75RjziKOcii4yQvMYYSA/viewform">this Google form</a>! If you are in Toronto and would like to come pick up swag early instead, come to the front of the Galbraith building (35 St. George St, Toronto, ON, M5S 1A4) on Monday, October 25th, 2021 from 12:15 to 1pm!</p>
+<p>If you'd like us to ship you some {{ hackathon_name }} swag, fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSePBlW8gLKOi27-8uUGTaUJMcywHT75RjziKOcii4yQvMYYSA/viewform">this Google form</a>!</p>
 
 <p>If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
 


### PR DESCRIPTION
## Overview

Exetnds registration to November 3rd, and removes the note from the accepted email about picking up swag in person.


## Unit Tests Created

- N/a


## Steps to QA

- N/a

